### PR TITLE
Make it so the output path can be configured

### DIFF
--- a/build/Common.Build.props
+++ b/build/Common.Build.props
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-	<PropertyGroup>
-		<BasePath>$(MSBuildThisFileDirectory)..\</BasePath>
-		<BaseIntermediateOutputPath>$(BasePath)artifacts\obj\$(OS)\$(MSBuildProjectName)\</BaseIntermediateOutputPath>
-		<RestoreProjectStyle Condition="'$(RestoreProjectStyle)' == ''">PackageReference</RestoreProjectStyle>
-	</PropertyGroup>
+  <PropertyGroup>
+    <BasePath>$(MSBuildThisFileDirectory)..\</BasePath>
+    <BaseIntermediateOutputPath Condition="$(BaseIntermediateOutputPath) == ''">$(BasePath)artifacts\obj\$(OS)\$(MSBuildProjectName)\</BaseIntermediateOutputPath>
+    <BaseOutputPath Condition="$(BaseOutputPath) == ''">$(BasePath)\artifacts\$(OutputArtifactName)\</BaseOutputPath>
+    <RestoreProjectStyle Condition="'$(RestoreProjectStyle)' == ''">PackageReference</RestoreProjectStyle>
+  </PropertyGroup>
   <Import Condition="Exists('$(BasePath)..\Eto.Toolkit.props')" Project="$(BasePath)..\Eto.Toolkit.props" />
 </Project>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,4 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <OutputArtifactName>core</OutputArtifactName>
+  </PropertyGroup>
   <Import Project="..\build\Common.Build.props" />
 </Project>

--- a/src/Eto.HtmlRenderer/Eto.HtmlRenderer.csproj
+++ b/src/Eto.HtmlRenderer/Eto.HtmlRenderer.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFrameworks>net45;netstandard2.0</TargetFrameworks>
     <HtmlRendererPath>..\..\lib\HtmlRenderer\</HtmlRendererPath>
-    <OutputPath>$(BasePath)\artifacts\core\$(Configuration)</OutputPath>
     <UseImageSharp Condition="$(UseImageSharp) == '' AND $(TargetFramework) == 'netstandard2.0'">True</UseImageSharp>
     <UseSystemDrawing Condition="$(UseSystemDrawing) == '' AND $(TargetFramework) == 'net45'">True</UseSystemDrawing>
   </PropertyGroup>

--- a/test/Directory.Build.props
+++ b/test/Directory.Build.props
@@ -1,4 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <OutputArtifactName>test</OutputArtifactName>
+  </PropertyGroup>
   <Import Project="..\build\Common.Build.props" />
 </Project>


### PR DESCRIPTION
This is needed when building different variations of Eto.HtmlRenderer.