### PR TITLE
Update to 1.0 to match what the assemblies were tagged as before.

### DIFF
--- a/build/Common.Build.props
+++ b/build/Common.Build.props
@@ -12,7 +12,7 @@
   </PropertyGroup>
   
   <PropertyGroup>
-    <DevVersion>0.3.0</DevVersion>
+    <DevVersion>1.0.0</DevVersion>
 
     <!-- set version from tag -->
     <Version Condition="$(BuildBranch.StartsWith('refs/tags/'))">$(BuildBranch.Substring(10))</Version>


### PR DESCRIPTION
ugh, windows installers are the worst.